### PR TITLE
Discover `updated_at` as automatically included for `products`

### DIFF
--- a/tap_shiphero/discover.py
+++ b/tap_shiphero/discover.py
@@ -14,6 +14,9 @@ PKS = {
     'vendors': ['vendor_id'],
     'shipments': ['shipment_id']
 }
+REPLICATION_KEYS = {
+    'products': ['updated_at']
+}
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
@@ -42,10 +45,13 @@ def get_schemas():
 
             SCHEMAS[stream_name] = schema
             pk = PKS[stream_name]
+            replication_key = REPLICATION_KEYS.get(stream_name, [])
             schema_metadata = metadata.new()
 
             for prop, json_schema in schema['properties'].items():
                 if prop in pk:
+                    inclusion = 'automatic'
+                elif prop in replication_key:
                     inclusion = 'automatic'
                 else:
                     inclusion = 'available'


### PR DESCRIPTION
Motivation
----------

The tap [uses `updated_at`][1] as the replication key for `products`.

[1]: https://github.com/singer-io/tap-shiphero/blob/997009436797f8deed8cf8b69f9d699e2dfe854a/tap_shiphero/sync.py#L95