### PR TITLE
Add bookmarks to pagination for sync_daily streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'backoff==1.3.2',
         'ratelimit==2.2.0',
         'requests==2.20.1',
-        'singer-python==5.2.0'
+        'singer-python==5.5.0'
     ],
     entry_points='''
       [console_scripts]

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -52,16 +52,12 @@ def sync_products(client, catalog, state, start_date, end_date, stream_id, strea
     last_date = bookmarks.get_bookmark(state, stream_id, 'datetime', start_date)
 
     # Rip this out once all bookmarks are converted
-    old_style_bookmark = bookmarks.get_bookmark(state, stream_id, stream_id)
-    if old_style_bookmark:
-        # Use the old style bookmark
-        last_date = old_style_bookmark
+    if isinstance(state.get('bookmarks',{}).get(stream_id), str):
+        # Old style bookmark found. Use it and delete it
+        last_date = state['bookmarks'][stream_id].pop()
 
         # Write this bookmark in the new style
         bookmarks.write_bookmark(state, stream_id, 'datetime', last_date)
-
-        # Purge the old style bookmark
-        bookmarks.clear_bookmark(state, stream_id, stream_id)
 
     def products_transform(record):
         out = {}
@@ -180,20 +176,15 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
                                                  start_date)
 
     # Rip this out once all bookmarks are converted
-    old_style_bookmark = bookmarks.get_bookmark(state,
-                                                stream_id,
-                                                stream_id)
-    if old_style_bookmark:
-        start_date_bookmark = old_style_bookmark
+    if isinstance(state.get('bookmarks',{}).get(stream_id), str):
+        # Old style bookmark found. Use it and delete it
+        old_style_bookmark = state['bookmarks'][stream_id].pop()
 
         # Write this bookmark in the new style
         bookmarks.write_bookmark(state,
                                  stream_id,
                                  'datetime',
                                  start_date_bookmark)
-
-        # Purge the old style bookmark
-        bookmarks.clear_bookmark(state, stream_id, stream_id)
 
     start_date_dt = strptime_to_utc(start_date_bookmark)
 

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -131,7 +131,7 @@ def sync_products(client, catalog, state, start_date, end_date, stream_id, strea
         else:
             num_results = 0
 
-        set_bookmark(state, stream_id, 'datetime', max_datetime)
+        bookmarks.write_bookmark(state, stream_id, 'datetime', max_datetime)
 
 def sync_vendors(client, catalog, state, start_date, end_date, stream_id, stream_config):
     stream_id = 'vendors'
@@ -183,7 +183,7 @@ def sync_a_day(stream_id, path, params, start_ymd, end_ymd,
             break
         else:
             persist_records(catalog, stream_id, records)
-            set_bookmark(state, stream_id, 'page', params['page'])
+            bookmarks.write_bookmark(state, stream_id, 'page', params['page'])
             params['page'] += 1
 
 def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_config):
@@ -270,7 +270,8 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
         sync_a_day(stream_id, path, params, start_ymd, end_ymd,
                    records_fn, client, catalog, state)
 
-        set_bookmark(state, stream_id, 'datetime', utils.strftime(window_end))
+        bookmarks.write_bookmark(state, stream_id, 'datetime', utils.strftime(window_end))
+        bookmarks.write_bookmark(state, stream_id, 'page', 1)
         start_date_dt = window_end
 
 def order_get_records(data):

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -52,7 +52,7 @@ def sync_products(client, catalog, state, start_date, end_date, stream_id, strea
     # Rip this out once all bookmarks are converted
     if isinstance(state.get('bookmarks',{}).get(stream_id), str):
         # Old style bookmark found. Use it and delete it
-        last_date = state['bookmarks'][stream_id].pop()
+        last_date = state['bookmarks'].pop(stream_id)
 
         # Write this bookmark in the new style
         bookmarks.write_bookmark(state, stream_id, 'datetime', last_date)
@@ -185,7 +185,7 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
     # Rip this out once all bookmarks are converted
     if isinstance(state.get('bookmarks',{}).get(stream_id), str):
         # Old style bookmark found. Use it and delete it
-        old_style_bookmark = state['bookmarks'][stream_id].pop()
+        old_style_bookmark = state['bookmarks'].pop(stream_id)
 
         # Write this bookmark in the new style
         bookmarks.write_bookmark(state,

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -79,23 +79,19 @@ def sync_products(client, catalog, state, start_date, end_date, stream_id, strea
 
     write_schema(catalog, stream_id)
 
-    last_date = bookmarks.get_bookmark(state, stream_id, 'datetime')
+    last_date = bookmarks.get_bookmark(state, stream_id, 'datetime', start_date)
 
-    if not last_date:
-        # Default to start_date
-        last_date = start_date
+    # Rip this out once all bookmarks are converted
+    old_style_bookmark = bookmarks.get_bookmark(state, stream_id, stream_id)
+    if old_style_bookmark:
+        # Use the old style bookmark
+        last_date = old_style_bookmark
 
-        # Rip this out once all bookmarks are converted
-        old_style_bookmark = bookmarks.get_bookmark(state, stream_id, stream_id)
-        if old_style_bookmark:
-            # Use the old style bookmark
-            last_date = old_style_bookmark
+        # Write this bookmark in the new style
+        bookmarks.write_bookmark(state, stream_id, 'datetime', last_date)
 
-            # Write this bookmark in the new style
-            bookmarks.write_bookmark(state, stream_id, 'datetime', last_date)
-
-            # Purge the old style bookmark
-            bookmarks.clear_bookmark(state, stream_id, stream_id)
+        # Purge the old style bookmark
+        bookmarks.clear_bookmark(state, stream_id, stream_id)
 
     def products_transform(record):
         out = {}
@@ -208,24 +204,26 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
     ### Set up datetime versions of the start_date, end_date
     #######################################################################
 
-    start_date_bookmark = bookmarks.get_bookmark(state, stream_id, 'datetime')
-    if not start_date_bookmark:
-        # Default to start_date
-        start_date_bookmark = start_date
+    start_date_bookmark = bookmarks.get_bookmark(state,
+                                                 stream_id,
+                                                 'datetime',
+                                                 start_date)
 
-        # Rip this out once all bookmarks are converted
-        old_style_bookmark = bookmarks.get_bookmark(state, stream_id, stream_id)
-        if old_style_bookmark:
-            start_date_bookmark = old_style_bookmark
+    # Rip this out once all bookmarks are converted
+    old_style_bookmark = bookmarks.get_bookmark(state,
+                                                stream_id,
+                                                stream_id)
+    if old_style_bookmark:
+        start_date_bookmark = old_style_bookmark
 
-            # Write this bookmark in the new style
-            bookmarks.write_bookmark(state,
-                                     stream_id,
-                                     'datetime',
-                                     start_date_bookmark)
+        # Write this bookmark in the new style
+        bookmarks.write_bookmark(state,
+                                 stream_id,
+                                 'datetime',
+                                 start_date_bookmark)
 
-            # Purge the old style bookmark
-            bookmarks.clear_bookmark(state, stream_id, stream_id)
+        # Purge the old style bookmark
+        bookmarks.clear_bookmark(state, stream_id, stream_id)
 
     start_date_dt = strptime_to_utc(start_date_bookmark)
 

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -32,36 +32,6 @@ def persist_records(catalog, stream_id, records):
                 singer.write_record(stream_id, record)
                 counter.increment()
 
-def set_bookmark(state, stream_id, field, value):
-    """Structure of the state dictionary:
-    {
-      "bookmarks": {
-        "stream1" : {
-          "datetime": "2019-01-01T00:00:00Z",
-          "page": 75
-        },
-        "stream2" : {
-          "datetime": "2019-01-01T00:00:00Z",
-          "page": 75
-        },
-        ...
-      }
-      ...
-    }
-    """
-    if 'bookmarks' not in state:
-        state['bookmarks'] = {}
-
-    # This is the old style, so convert it to a dict
-    if isinstance(state['bookmarks'][stream_id], string):
-        state['bookmarks'][stream_id] = {}
-
-    if not isinstance(state['bookmarks'][stream_id], dict):
-        raise Exception('Unexpected bookmark format')
-
-    state['bookmarks'][stream_id][field] = value
-    singer.write_state(state)
-
 def get_selected_streams(catalog):
     selected_streams = set()
     for stream in catalog.streams:

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -161,8 +161,7 @@ def sync_a_day(stream_id, path, params, start_ymd, end_ymd,
             break
         else:
             persist_records(catalog, stream_id, records)
-            if params['page'] % 10 == 0:
-                update_page_bookmark(state, page_bookmark_key, params['page'])
+            update_page_bookmark(state, page_bookmark_key, params['page'])
             params['page'] += 1
 
 def get_page_bookmark(state, stream_id):

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -182,11 +182,6 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
     ### Set up datetime versions of the start_date, end_date
     #######################################################################
 
-    start_date_bookmark = bookmarks.get_bookmark(state,
-                                                 stream_id,
-                                                 'datetime',
-                                                 start_date)
-
     # Rip this out once all bookmarks are converted
     if isinstance(state.get('bookmarks',{}).get(stream_id), str):
         # Old style bookmark found. Use it and delete it
@@ -196,7 +191,12 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
         bookmarks.write_bookmark(state,
                                  stream_id,
                                  'datetime',
-                                 start_date_bookmark)
+                                 old_style_bookmark)
+
+    start_date_bookmark = bookmarks.get_bookmark(state,
+                                                 stream_id,
+                                                 'datetime',
+                                                 start_date)
 
     start_date_dt = strptime_to_utc(start_date_bookmark)
 

--- a/tap_shiphero/sync.py
+++ b/tap_shiphero/sync.py
@@ -117,7 +117,7 @@ def sync_vendors(client, catalog, state, start_date, end_date, stream_id, stream
     persist_records(catalog, stream_id, records)
 
 def sync_a_day(stream_id, path, params, start_ymd, end_ymd,
-               func_get_records, client, catalog, state):
+               func_get_records, client, catalog, state, window_end):
     """Sync a single day's worth of data, paginating through as many times as
     necessary.
 
@@ -156,7 +156,7 @@ def sync_a_day(stream_id, path, params, start_ymd, end_ymd,
                 stream_id,
                 params['page'])
             bookmarks.write_bookmark(state, stream_id, 'page', 1)
-            bookmarks.write_bookmark(state, stream_id, 'datetime', utils.strftime(end_ymd))
+            bookmarks.write_bookmark(state, stream_id, 'datetime', utils.strftime(window_end))
             singer.write_state(state)
             break
         else:
@@ -239,7 +239,7 @@ def sync_daily(client, catalog, state, start_date, end_date, stream_id, stream_c
                        to_col: end_ymd})
 
         sync_a_day(stream_id, path, params, start_ymd, end_ymd,
-                   records_fn, client, catalog, state)
+                   records_fn, client, catalog, state, window_end)
 
         start_date_dt = window_end
 


### PR DESCRIPTION
Sometimes people have really large result sets for a given day. If the tap errors in that sync, I want to resume on a nearby page. I don't have a strong opinion about how often this bookmark is saved, so suggestions are welcome.